### PR TITLE
Add more KMP targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,19 +40,18 @@ kotlin {
         }
     }
 
+    macosX64()
+    macosArm64()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    tvosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    
     mingwX64()
     linuxX64()
     linuxArm64()
-
-    val hostOs = System.getProperty("os.name")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" -> macosX64("native")
-        hostOs == "Linux" -> linuxX64("native")
-        isMingwX64 -> mingwX64("native")
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
-
 
     sourceSets {
         val commonMain by getting
@@ -67,7 +66,5 @@ kotlin {
         val jvmTest by getting
         val jsMain by getting
         val jsTest by getting
-        val nativeMain by getting
-        val nativeTest by getting
     }
 }


### PR DESCRIPTION
Hey!

I've added a few more KMP targets so things work out of the box when declaring a dependency on your lib. We have for example a tvOS target and Gradle couldn't find a matching library from your KMP lib.

I've tested this locally via `mavenLocal()`.

If this is fine for you would be great if you would release a new version afterwards.